### PR TITLE
Make promise generic

### DIFF
--- a/SwiftPromise.xcodeproj/xcuserdata/mozilla.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/SwiftPromise.xcodeproj/xcuserdata/mozilla.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -42,11 +42,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "SwiftPromiseTests/SwiftPromiseTests.swift"
-            timestampString = "453449541.607879"
+            timestampString = "454399530.898824"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "121"
-            endingLineNumber = "121"
+            startingLineNumber = "154"
+            endingLineNumber = "154"
             landmarkName = "testChainingPromises2()"
             landmarkType = "5">
          </BreakpointContent>

--- a/SwiftPromise.xcodeproj/xcuserdata/mozilla.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/SwiftPromise.xcodeproj/xcuserdata/mozilla.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -51,21 +51,5 @@
             landmarkType = "5">
          </BreakpointContent>
       </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "SwiftPromise/Promise.swift"
-            timestampString = "454400993.711924"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "29"
-            endingLineNumber = "29"
-            landmarkName = "then(_:onRejected:)"
-            landmarkType = "5">
-         </BreakpointContent>
-      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/SwiftPromise.xcodeproj/xcuserdata/mozilla.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/SwiftPromise.xcodeproj/xcuserdata/mozilla.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -51,5 +51,21 @@
             landmarkType = "5">
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "SwiftPromise/Promise.swift"
+            timestampString = "454400993.711924"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "29"
+            endingLineNumber = "29"
+            landmarkName = "then(_:onRejected:)"
+            landmarkType = "5">
+         </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>


### PR DESCRIPTION
This is a first attempt at generics here. Makes promise generic. Also fixes some bugs with error cascading.

Since you often want to return different types of objects from different promises. Most use cases seem to need <Any> as their generic type making this less than useful. Looking into a way to store blocks that have different types of arguments to work around this....
